### PR TITLE
Fix deep URL routing for writing pages

### DIFF
--- a/client_app.py
+++ b/client_app.py
@@ -5,14 +5,12 @@ from flask import Blueprint, send_from_directory
 client = Blueprint("client", __name__, static_folder=path.join("frontend", "build"))
 
 
-@client.route("/", defaults={"file_name": "", "id": ""})
-@client.route("/<string:file_name>", defaults={"id": ""})
-@client.route("/<string:file_name>/<string:id>")
-def serve(file_name, id):
-    if file_name != "" and path.exists(path.join(client.static_folder, file_name)):
-        return send_from_directory(client.static_folder, file_name)
-    else:
-        return send_from_directory(client.static_folder, "index.html")
+@client.route("/", defaults={"file_path": ""})
+@client.route("/<path:file_path>")
+def serve(file_path):
+    if file_path and path.exists(path.join(client.static_folder, file_path)):
+        return send_from_directory(client.static_folder, file_path)
+    return send_from_directory(client.static_folder, "index.html")
 
 
 @client.route("/static/<path:path_to_file>/<string:file_name>")


### PR DESCRIPTION
## Summary
- fix Flask client blueprint to serve index.html on nested routes

## Testing
- `npm run build --prefix frontend`
- `python -m py_compile client_app.py wsgi.py backend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_6841626879c88320904340afffa854aa