### PR TITLE
Add metadata to remaining pages

### DIFF
--- a/frontend/src/pages/Bookmarks.js
+++ b/frontend/src/pages/Bookmarks.js
@@ -1,6 +1,7 @@
 // File: src/pages/Bookmarks.js
 import React from "react";
 import { Routes, Route, useParams } from "react-router-dom";
+import { Helmet } from "react-helmet";
 import { useContext } from "react";
 import { InstagramEmbed } from 'react-social-media-embed';
 import { MobileViewContext } from "../context/MobileViewContext";
@@ -89,6 +90,28 @@ export const bookmarkCategories = [
 function BookmarksHome() {
   return (
     <div>
+      <Helmet>
+        <title>Bookmarks | Helia Jamshidi</title>
+        <meta
+          name="description"
+          content="Curated list of books, podcasts and other recommendations from Helia Jamshidi."
+        />
+        <meta
+          name="keywords"
+          content="bookmarks, book recommendations, podcasts, web links, Helia Jamshidi"
+        />
+        <meta property="og:title" content="Bookmarks | Helia Jamshidi" />
+        <meta
+          property="og:description"
+          content="A collection of useful references including books and podcasts."
+        />
+        <meta
+          property="og:url"
+          content="https://heliajamshidi.me/bookmarks"
+        />
+        <meta property="og:type" content="website" />
+        <link rel="canonical" href="https://heliajamshidi.me/bookmarks" />
+      </Helmet>
       <h1>Books Overview</h1>
       <p>
         I think people's perspectives on life and things that interest them are so diverse that hardly any material or book can be recommended without knowing their context. But I have come to make some exceptions only because I wish someone had given me these earlier in my life. We are very different, yet we share at least some biology and we also share the systems that we live in.
@@ -406,6 +429,19 @@ function BookmarkDetail() {
 
   return (
     <div>
+      <Helmet>
+        <title>{`${info.name || "Bookmark"} | Bookmarks | Helia Jamshidi`}</title>
+        <meta
+          name="description"
+          content={`Details and links for ${info.name || "this bookmark"} curated by Helia Jamshidi.`}
+        />
+        <meta property="og:title" content={`${info.name || "Bookmark"} | Bookmarks | Helia Jamshidi`} />
+        <meta
+          property="og:description"
+          content={`Find out more about ${info.name || "this bookmark"} on Helia's personal site.`}
+        />
+        <meta property="og:type" content="article" />
+      </Helmet>
       <h1>{info.name || "Unknown Bookmark"}</h1>
       {info.url && (
         <button

--- a/frontend/src/pages/Interactive.js
+++ b/frontend/src/pages/Interactive.js
@@ -1,6 +1,7 @@
 // File: src/pages/Interactive.js
 import React from "react";
 import { Routes, Route } from "react-router-dom";
+import { Helmet } from "react-helmet";
 import { useContext } from "react";
 import { MobileViewContext } from "../context/MobileViewContext";
 import SecondarySidebarBasic from "../components/SecondarySidebarBasic";
@@ -17,6 +18,21 @@ const interactiveItems = [
 function InteractiveHome() {
   return (
     <div>
+      <Helmet>
+        <title>Interactive Tools | Helia Jamshidi</title>
+        <meta
+          name="description"
+          content="Book time, ask questions or share a message with Helia Jamshidi."
+        />
+        <meta property="og:title" content="Interactive Tools | Helia Jamshidi" />
+        <meta
+          property="og:description"
+          content="Choose from booking, AMA or sharing a message to connect."
+        />
+        <meta property="og:url" content="https://heliajamshidi.me/interactive" />
+        <meta property="og:type" content="website" />
+        <link rel="canonical" href="https://heliajamshidi.me/interactive" />
+      </Helmet>
       <h2>Interactive Overview</h2>
       <p>Select a tool from the sidebar.</p>
     </div>

--- a/frontend/src/pages/Projects.js
+++ b/frontend/src/pages/Projects.js
@@ -1,6 +1,7 @@
 // File: src/pages/Projects.js
 import React, { useState } from "react";
 import { useContext } from "react";
+import { Helmet } from "react-helmet";
 import { Routes, Route, useParams } from "react-router-dom";
 import { MobileViewContext } from "../context/MobileViewContext";
 import SecondarySidebarBasic from "../components/SecondarySidebarBasic";
@@ -14,6 +15,25 @@ const projectItems = [
 function ProjectsHome() {
   return (
     <div>
+      <Helmet>
+        <title>Projects | Helia Jamshidi</title>
+        <meta
+          name="description"
+          content="Overview of personal and experimental projects by Helia Jamshidi."
+        />
+        <meta
+          name="keywords"
+          content="Helia Jamshidi projects, Jous, Emotion Explorer"
+        />
+        <meta property="og:title" content="Projects | Helia Jamshidi" />
+        <meta
+          property="og:description"
+          content="Discover apps and tools Helia is building or experimenting with."
+        />
+        <meta property="og:url" content="https://heliajamshidi.me/projects" />
+        <meta property="og:type" content="website" />
+        <link rel="canonical" href="https://heliajamshidi.me/projects" />
+      </Helmet>
       <h2>Projects Overview</h2>
       <p>Choose a project to findout more about it.</p>
     </div>
@@ -23,6 +43,21 @@ function ProjectsHome() {
 function Jous() {
   return (
     <div>
+      <Helmet>
+        <title>Jous Conversation Cards | Helia Jamshidi</title>
+        <meta
+          name="description"
+          content="Community app with conversation questions to spark meaningful dialogue."
+        />
+        <meta property="og:title" content="Jous Conversation Cards | Helia Jamshidi" />
+        <meta
+          property="og:description"
+          content="Discover Jous, an app for avoiding small talk and connecting over thoughtful questions."
+        />
+        <meta property="og:url" content="https://heliajamshidi.me/projects/jous" />
+        <meta property="og:type" content="website" />
+        <link rel="canonical" href="https://heliajamshidi.me/projects/jous" />
+      </Helmet>
       <h1>Jous Conversation Cards</h1>
       <p>This App is for people trying to avoid small talk. It is a cozy community for questions that spark conversations. But it is not Reddit! To answer questions in Jous, you should search inward, inside yourself. For families, friends, dates, and strangers. Anyone can share questions on Jous, the question set changes daily.</p>
       <div className="sample-images-section">
@@ -70,6 +105,21 @@ function EmotionResolver() {
 
   return (
     <div className="container">
+      <Helmet>
+        <title>Emotion Explorer | Helia Jamshidi</title>
+        <meta
+          name="description"
+          content="Tool to discover nuanced emotions and their cultural context."
+        />
+        <meta property="og:title" content="Emotion Explorer | Helia Jamshidi" />
+        <meta
+          property="og:description"
+          content="Find more specific words for how you feel using this simple app."
+        />
+        <meta property="og:url" content="https://heliajamshidi.me/projects/emotion-explorer" />
+        <meta property="og:type" content="website" />
+        <link rel="canonical" href="https://heliajamshidi.me/projects/emotion-explorer" />
+      </Helmet>
       <h1>Emotion Explorer</h1>
       <h4 style={{textAlign: "center", marginTop:"0px", marginBottom:"3rem"}}>Find out similar but more specific emotions from other cultures</h4>
 

--- a/frontend/src/pages/SocialMedia.js
+++ b/frontend/src/pages/SocialMedia.js
@@ -1,6 +1,7 @@
 // File: src/pages/SocialMedia.js
 import React from "react";
 import { Routes, Route, useParams } from "react-router-dom";
+import { Helmet } from "react-helmet";
 
 const socialItems = [
   {
@@ -44,6 +45,21 @@ const socialItems = [
 export default function SocialMedia() {
   return (
     <div className="content-with-sub">
+      <Helmet>
+        <title>Social Media Links | Helia Jamshidi</title>
+        <meta
+          name="description"
+          content="Find Helia on Twitter, LinkedIn, GitHub, Instagram and TikTok."
+        />
+        <meta property="og:title" content="Social Media Links | Helia Jamshidi" />
+        <meta
+          property="og:description"
+          content="Quick links to Helia's profiles across major platforms."
+        />
+        <meta property="og:url" content="https://heliajamshidi.me/social-media" />
+        <meta property="og:type" content="website" />
+        <link rel="canonical" href="https://heliajamshidi.me/social-media" />
+      </Helmet>
       <div className="sub-sidebar" style={{ textAlign: "left" }}>
         <h3 style={{ margin: "0 0 4px", fontSize: "0.9rem" }}>Social Media</h3>
         <ul style={{ margin: 0, padding: 0, listStyle: "none" }}>

--- a/frontend/src/pages/interactive/AMA.js
+++ b/frontend/src/pages/interactive/AMA.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import axios from "axios";
+import { Helmet } from "react-helmet";
 import "./AMA.css";
 
 export default function AMA() {
@@ -88,6 +89,21 @@ export default function AMA() {
 
   return (
     <>
+      <Helmet>
+        <title>Ask Me Anything | Helia Jamshidi</title>
+        <meta
+          name="description"
+          content="Submit anonymous questions for Helia Jamshidi to answer."
+        />
+        <meta property="og:title" content="Ask Me Anything | Helia Jamshidi" />
+        <meta
+          property="og:description"
+          content="Send in your questions and read the answers here."
+        />
+        <meta property="og:url" content="https://heliajamshidi.me/interactive/ama" />
+        <meta property="og:type" content="website" />
+        <link rel="canonical" href="https://heliajamshidi.me/interactive/ama" />
+      </Helmet>
       <div className="ama-container">
         <h2>Ask Me Anything</h2>
         <form className="question-form" onSubmit={submitQuestion}>

--- a/frontend/src/pages/interactive/BookCalendar.js
+++ b/frontend/src/pages/interactive/BookCalendar.js
@@ -1,10 +1,26 @@
 // File: src/pages/interactive/BookCalendar.js
 import React from "react";
+import { Helmet } from "react-helmet";
 import "./BookCalendar.css";
 
 export default function BookCalendar() {
   return (
     <div className="book-calendar-container">
+      <Helmet>
+        <title>Book My Calendar | Helia Jamshidi</title>
+        <meta
+          name="description"
+          content="Schedule a meeting with Helia Jamshidi using the embedded Calendly widget."
+        />
+        <meta property="og:title" content="Book My Calendar | Helia Jamshidi" />
+        <meta
+          property="og:description"
+          content="Choose a suitable time slot for a call or meeting."
+        />
+        <meta property="og:url" content="https://heliajamshidi.me/interactive/book" />
+        <meta property="og:type" content="website" />
+        <link rel="canonical" href="https://heliajamshidi.me/interactive/book" />
+      </Helmet>
       <h2>Book My Calendar</h2>
       <p>Select a suitable time for our meeting.</p>
       <div className="calendly-embed">

--- a/frontend/src/pages/interactive/ShareMessage.js
+++ b/frontend/src/pages/interactive/ShareMessage.js
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import axios from "axios";
+import { Helmet } from "react-helmet";
 
 export default function ShareMessage() {
   const [message, setMessage] = useState("");
@@ -24,6 +25,21 @@ export default function ShareMessage() {
 
   return (
     <div className="ama-container">
+      <Helmet>
+        <title>Share Anything With Me | Helia Jamshidi</title>
+        <meta
+          name="description"
+          content="Send a personal message or feedback directly to Helia Jamshidi."
+        />
+        <meta property="og:title" content="Share Anything With Me | Helia Jamshidi" />
+        <meta
+          property="og:description"
+          content="Submit your thoughts or ideas privately through this form."
+        />
+        <meta property="og:url" content="https://heliajamshidi.me/interactive/share" />
+        <meta property="og:type" content="website" />
+        <link rel="canonical" href="https://heliajamshidi.me/interactive/share" />
+      </Helmet>
       <h2>Share Anything With Me</h2>
       <input
         placeholder="Name (optional)"


### PR DESCRIPTION
## Summary
- add Helmet metadata to Bookmarks pages
- set metadata on Projects subroutes
- include meta tags for Interactive and subpages
- add SEO data for Social Media page

## Testing
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847dd17f43c8320a845a3ff4dca03f1