### PR TITLE
Add two new projects

### DIFF
--- a/frontend/src/pages/Home.js
+++ b/frontend/src/pages/Home.js
@@ -148,7 +148,23 @@ export default function Home() {
             <img
               key={0}
               src="https://res.cloudinary.com/dl9xg597r/image/upload/f_webp/q_auto:low/v1738794201/Screenshot_2025-01-29_210213_amqqyk.png"
-              alt="Sample 1"
+              alt="Jous screenshot"
+              className="gallery-image"
+            />
+          </a>
+          <a href="https://seconddate.date/swipe" target="_blank" rel="noopener noreferrer">
+            <img
+              key={1}
+              src="https://res.cloudinary.com/dl9xg597r/image/upload/v1748245861/sticker_2_boring_coffee_date_shvkfc.png"
+              alt="Second Date screenshot"
+              className="gallery-image"
+            />
+          </a>
+          <a href="https://tango-diario.com/" target="_blank" rel="noopener noreferrer">
+            <img
+              key={2}
+              src="https://tango-diario.com/lovable-uploads/3e4f67a7-9a5c-4d34-b8aa-fa7bad6095c4.png"
+              alt="Tango Diario screenshot"
               className="gallery-image"
             />
           </a>

--- a/frontend/src/pages/Projects.js
+++ b/frontend/src/pages/Projects.js
@@ -10,6 +10,8 @@ import "./Projects.css"
 const projectItems = [
   { label: "Jous", route: "/projects/jous" },
   { label: "Emotion Explorer", route: "/projects/emotion-explorer" },
+  { label: "Second Date", route: "/projects/second-date" },
+  { label: "Tango Diario", route: "/projects/tango-diario" },
 ];
 
 function ProjectsHome() {
@@ -23,7 +25,7 @@ function ProjectsHome() {
         />
         <meta
           name="keywords"
-          content="Helia Jamshidi projects, Jous, Emotion Explorer"
+          content="Helia Jamshidi projects, Jous, Emotion Explorer, Second Date, Tango Diario"
         />
         <meta property="og:title" content="Projects | Helia Jamshidi" />
         <meta
@@ -67,6 +69,78 @@ function Jous() {
               key={0}
               src="https://res.cloudinary.com/dl9xg597r/image/upload/f_webp/q_auto:low/v1738794201/Screenshot_2025-01-29_210213_amqqyk.png"
               alt="Sample 1"
+              className="gallery-image"
+              style={{width: "50rem", maxWidth: "90%"}}
+            />
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SecondDate() {
+  return (
+    <div>
+      <Helmet>
+        <title>Second Date | Helia Jamshidi</title>
+        <meta
+          name="description"
+          content="Swipe through fun date ideas contributed by the community."
+        />
+        <meta property="og:title" content="Second Date | Helia Jamshidi" />
+        <meta
+          property="og:description"
+          content="Explore Helia's experiment to make dating less like work."
+        />
+        <meta property="og:url" content="https://heliajamshidi.me/projects/second-date" />
+        <meta property="og:type" content="website" />
+        <link rel="canonical" href="https://heliajamshidi.me/projects/second-date" />
+      </Helmet>
+      <h1>Second Date</h1>
+      <p>Swipe-based collection of first-date ideas aimed at making dates playful and engaging.</p>
+      <div className="sample-images-section">
+        <div className="image-gallery" >
+          <a href="https://seconddate.date/swipe" target="_blank" rel="noopener noreferrer">
+            <img
+              src="https://res.cloudinary.com/dl9xg597r/image/upload/v1748245861/sticker_2_boring_coffee_date_shvkfc.png"
+              alt="Second Date screenshot"
+              className="gallery-image"
+              style={{width: "50rem", maxWidth: "90%"}}
+            />
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TangoDiario() {
+  return (
+    <div>
+      <Helmet>
+        <title>Tango Diario | Helia Jamshidi</title>
+        <meta
+          name="description"
+          content="A daily five-minute practice tool for tango musicality."
+        />
+        <meta property="og:title" content="Tango Diario | Helia Jamshidi" />
+        <meta
+          property="og:description"
+          content="Practice tango musicality step by step with weekly topics."
+        />
+        <meta property="og:url" content="https://heliajamshidi.me/projects/tango-diario" />
+        <meta property="og:type" content="website" />
+        <link rel="canonical" href="https://heliajamshidi.me/projects/tango-diario" />
+      </Helmet>
+      <h1>Tango Diario</h1>
+      <p>Practice tango musicality with short daily exercises and weekly themes.</p>
+      <div className="sample-images-section">
+        <div className="image-gallery" >
+          <a href="https://tango-diario.com/" target="_blank" rel="noopener noreferrer">
+            <img
+              src="https://tango-diario.com/lovable-uploads/3e4f67a7-9a5c-4d34-b8aa-fa7bad6095c4.png"
+              alt="Tango Diario screenshot"
               className="gallery-image"
               style={{width: "50rem", maxWidth: "90%"}}
             />
@@ -177,6 +251,8 @@ export default function Projects({isMobile}) {
           <Route path="/" element={<ProjectsHome />} />
           <Route path="/jous" element={<Jous />} />
           <Route path="/emotion-explorer" element={<EmotionResolver />} />
+          <Route path="/second-date" element={<SecondDate />} />
+          <Route path="/tango-diario" element={<TangoDiario />} />
         </Routes>
       </div>}
     </div>


### PR DESCRIPTION
## Summary
- show Second Date and Tango Diario on the Home page
- add both projects in Projects page navigation
- implement project pages for Second Date and Tango Diario
- update metadata keywords

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685d481478a8832091550f87fb20b3b4