### PR TITLE
Remove Karlsruhe references from website content

### DIFF
--- a/frontend/src/pages/Home.js
+++ b/frontend/src/pages/Home.js
@@ -8,12 +8,12 @@ export default function Home() {
     <div className="home-container">
       <div className="lost-items-banner" role="alert" aria-live="polite">
         <p>
-          <strong>Deutsch:</strong> Am 14. März habe ich in Karlsruhe meine Karte und eine kleine braune Ledertasche verloren.
+          <strong>Deutsch:</strong> Am 14. März habe ich meine Karte und eine kleine braune Ledertasche verloren.
           Wenn du diese Website über meinen Ausweis gefunden hast, hast du die richtige Person gefunden.
           Bitte kontaktiere mich unter <a href="mailto:helia.jm@gmail.com">helia.jm@gmail.com</a>.
         </p>
         <p>
-          <strong>English:</strong> On March 14th, I lost my card and a small brown leather bag in Karlsruhe.
+          <strong>English:</strong> On March 14th, I lost my card and a small brown leather bag.
           If you found this website through my ID, you found the right person.
           Please contact me at <a href="mailto:helia.jm@gmail.com">helia.jm@gmail.com</a>.
         </p>
@@ -26,7 +26,7 @@ export default function Home() {
         />
         <meta
           name="keywords"
-          content="Helia Jamshidi, Software engineer, creator, tango dancer, collaboration, community building, karlsruhe"
+          content="Helia Jamshidi, Software engineer, creator, tango dancer, collaboration, community building"
         />
         <meta name="author" content="Helia Jamshidi" />
 
@@ -69,13 +69,13 @@ export default function Home() {
           The purpose of this homepage is to explain who I am and what I desire most from you, and how I can include you in my life.
         </p>
         <p>
-          I’m an Iranian-born woman who moved to the Netherlands at 23, and three years later to Karlsruhe, Germany, where I’ve lived for over four years.
-          While I have a fulfilling personal life, my connection to the city and its people is minimal, and I want that to change.
+          I’m an Iranian-born woman who moved to the Netherlands at 23, and three years later to Germany, where I’ve lived for over four years.
+          While I have a fulfilling personal life, my connection to the local community is minimal, and I want that to change.
           This website offers a glimpse of who I am, helping you decide if you want to get to know me, if you want me to know you, or if we can do something together and stay connected.
         </p>
         <p>
           I once spent a week in Lisbon and two weeks in Berlin, and I met so many people so fast. It made me sad to realize how much more spark
-          I had in those short trips than I’ve had in four years in Karlsruhe. It feels like something I can change, and I’m determined to try.
+          I had in those short trips than I’ve had at home over the years. It feels like something I can change, and I’m determined to try.
         </p>
         <p>
           Another reason I’ve made this space is that repeating my life story every time I meet a new person takes ages, and I want to experiment

--- a/frontend/src/pages/Work.js
+++ b/frontend/src/pages/Work.js
@@ -210,7 +210,7 @@ function Collaborate() {
 
         <ul >
           <li >
-            <strong>Local Collaborations in Karlsruhe:</strong> I want to
+            <strong>Local Collaborations:</strong> I want to
             experiment with new event formats that foster deeper connections
             without pressure. Think reading quietly together, conversation
             groups using prompts from apps like <a href="https://jous.app" target="_blank" rel="noopener noreferrer" style={{ color: '#0077cc' }}>Jous App</a>, or even exploring physical contact. I’ll

--- a/frontend/src/pages/Writing.js
+++ b/frontend/src/pages/Writing.js
@@ -353,43 +353,43 @@ const MentoringSection = () => {
     <div>
       <Helmet>
         {/* General SEO Tags */}
-        <title>Learn Argentine Tango in Karlsruhe | Mentoring for Beginners</title>
+        <title>Learn Argentine Tango | Mentoring for Beginners</title>
         <meta
           name="description"
-          content="Join personalized mentoring sessions for Argentine Tango in Karlsruhe. Learn balance, musicality, and milonga techniques. Perfect for beginners and young dancers."
+          content="Join personalized mentoring sessions for Argentine Tango. Learn balance, musicality, and milonga techniques. Perfect for beginners and young dancers."
         />
         <meta
           name="keywords"
-          content="Argentine Tango Karlsruhe, learn milonga, tango mentoring, tango beginners, tango dance Karlsruhe, tango musicality, tango balance, tango community Karlsruhe"
+          content="Argentine Tango, learn milonga, tango mentoring, tango beginners, tango dance, tango musicality, tango balance, tango community"
         />
 
         {/* German SEO Tags */}
         <meta
           name="description"
           lang="de"
-          content="Lernen Sie Argentinischen Tango in Karlsruhe mit persönlichem Mentoring für Anfänger. Verbessern Sie Balance, Musikalität und Milonga-Techniken. Perfekt für junge Tänzer und Einsteiger."
+          content="Lernen Sie Argentinischen Tango mit persönlichem Mentoring für Anfänger. Verbessern Sie Balance, Musikalität und Milonga-Techniken. Perfekt für junge Tänzer und Einsteiger."
         />
         <meta
           name="keywords"
           lang="de"
-          content="Argentinischer Tango Karlsruhe, Milonga lernen, Tango Mentoring, Tango Anfänger, Tango tanzen Karlsruhe, Tango Musikalität, Tango Balance, Tango Gemeinschaft Karlsruhe"
+          content="Argentinischer Tango, Milonga lernen, Tango Mentoring, Tango Anfänger, Tango tanzen, Tango Musikalität, Tango Balance, Tango Gemeinschaft"
         />
 
         {/* Open Graph Tags (for social media sharing) */}
-        <meta property="og:title" content="Learn Argentine Tango in Karlsruhe | Mentoring for Beginners" />
+        <meta property="og:title" content="Learn Argentine Tango | Mentoring for Beginners" />
         <meta
           property="og:description"
-          content="Join personalized mentoring sessions for Argentine Tango in Karlsruhe. Learn balance, musicality, and milonga techniques. Perfect for beginners and young dancers."
+          content="Join personalized mentoring sessions for Argentine Tango. Learn balance, musicality, and milonga techniques. Perfect for beginners and young dancers."
         />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://heliajamshidi.me/writing/tango/mentoring" />
 
         {/* Twitter Card Tags */}
         <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content="Learn Argentine Tango in Karlsruhe | Mentoring for Beginners" />
+        <meta name="twitter:title" content="Learn Argentine Tango | Mentoring for Beginners" />
         <meta
           name="twitter:description"
-          content="Join personalized mentoring sessions for Argentine Tango in Karlsruhe. Learn balance, musicality, and milonga techniques. Perfect for beginners and young dancers."
+          content="Join personalized mentoring sessions for Argentine Tango. Learn balance, musicality, and milonga techniques. Perfect for beginners and young dancers."
         />
 
         {/* Canonical Link */}
@@ -426,10 +426,10 @@ const MentoringSection = () => {
         <section className="call-to-action">
           <h3>Join the Community</h3>
           <p>
-            To have a place to practice, you have to be a member of <strong>Tanzsportclub Astoria Karlsruhe</strong>. Membership is <strong>60 euros per 3 months</strong>, or you can suggest your own location.
+            To have a place to practice, you have to be a member of a local tango club. Membership is <strong>60 euros per 3 months</strong>, or you can suggest your own location.
           </p>
           <p>
-            This is part of my wish to expand my community in Karlsruhe, and I am sure you have something I can learn from you. <strong>We will find out.</strong>
+            This is part of my wish to expand my community, and I am sure you have something I can learn from you. <strong>We will find out.</strong>
           </p>
           <a href="mailto:helia.jm@gmail.com" className="submit-button">
             Write Me


### PR DESCRIPTION
### Motivation
- Remove all explicit mentions of the city "Karlsruhe" so the site no longer exposes the current city of residence.
- Generalize local references and SEO metadata to avoid city-specific targeting while preserving intent (lost-item notice, collaborations, and tango mentoring info).

### Description
- Updated `frontend/src/pages/Home.js` to remove "Karlsruhe" from the lost-items banner, remove `karlsruhe` from the homepage `keywords` meta, and generalized the personal bio location language.
- Updated `frontend/src/pages/Work.js` to change the collaboration heading from `Local Collaborations in Karlsruhe` to `Local Collaborations`.
- Updated `frontend/src/pages/Writing.js` to remove "Karlsruhe" from the page title, English and German SEO `description` and `keywords`, OG/Twitter titles and descriptions, and replaced `Tanzsportclub Astoria Karlsruhe` with a generic `local tango club` and removed the city-specific community line.
- Committed the edits to the branch after applying the content changes.

### Testing
- Ran `rg -n "Karlsruhe|karlsruhe" frontend/src` and confirmed there are no remaining matches in `frontend/src`, and the search succeeded.
- Ran `rg -n "Karlsruhe|karlsruhe" .` across the repository to verify no lingering occurrences and the search succeeded.
- Verified repository state with `git -C /workspace/personalWebsite status --short` and committed the changes with a descriptive message, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9edd4176c8320b694a7ea345fb705)